### PR TITLE
Pin versions in `main.yml` GitHub Action to get CI working

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.x
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pre-commit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade poetry
+        python -m pip install --upgrade poetry==0.12.17
         python -m poetry install
         sudo apt-get update -qq && sudo apt-get install -qq libimage-exiftool-perl
     - name: Test with pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     needs: lint
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
The `main.yml` GitHub Action is currently broken, since it doesn't work with the latest versions of Poetry/Python3. Pinning these versions to older ones fixes this (and it's what we should have done in the first place!).

